### PR TITLE
日付フォーマット関数にローカリゼーションを追加

### DIFF
--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,4 +1,5 @@
 import { Day } from "@/types/day";
+import i18n from "@/locales";
 
 export const getFormattedDate = (day: Day): string => {
   const date = new Date();
@@ -7,9 +8,19 @@ export const getFormattedDate = (day: Day): string => {
   } else if (day === "tomorrow") {
     date.setDate(date.getDate() + 1);
   }
-  return date.toLocaleDateString("ja-JP", {
+  
+  // 現在のロケール設定を取得
+  const currentLocale = i18n.locale;
+  
+  // ロケールに応じて適切なオプションを設定
+  const options: Intl.DateTimeFormatOptions = {
     year: "numeric",
     month: "long",
     day: "numeric",
-  });
+  };
+  
+  // 日本語の場合は日本語ロケールを使用
+  const locale = currentLocale === "ja" ? "ja-JP" : "en-US";
+  
+  return date.toLocaleDateString(locale, options);
 };


### PR DESCRIPTION
現在のロケールに応じて日付をフォーマットする機能を実装。日本語の場合は「ja-JP」、それ以外は「en-US」を使用。