### PR TITLE
データベースクライアントの統合とタスク管理機能の改善

### DIFF
--- a/components/dummy-json-data.tsx
+++ b/components/dummy-json-data.tsx
@@ -1,19 +1,13 @@
-import * as schema from "@/db/schema";
-import { Task } from "@/db/schema";
-import { drizzle } from "drizzle-orm/expo-sqlite";
-import { useSQLiteContext } from "expo-sqlite";
+import { db } from "@/db/client";
+import { Task, taskTable } from "@/db/schema";
 import { useEffect, useState } from "react";
 import { Text, View } from "react-native";
 
 export default function DummyJsonData() {
   const [tasks, setTasks] = useState<Task[]>([]);
-
-  const db = useSQLiteContext();
-  const drizzleDb = drizzle(db, { schema });
-
   useEffect(() => {
     const load = async () => {
-      const tasks = await drizzleDb.query.tasks.findMany();
+      const tasks = await db.select().from(taskTable);
       setTasks(tasks);
     };
     load();

--- a/components/task-form-dialog.tsx
+++ b/components/task-form-dialog.tsx
@@ -1,3 +1,5 @@
+import { db } from "@/db/client";
+import { taskTable } from "@/db/schema";
 import { getFormattedDateFromString } from "@/utils/date";
 import { useLocalization } from "@/utils/localization-context";
 import { Ionicons } from "@expo/vector-icons";
@@ -61,11 +63,16 @@ export default function TaskFormDialog({
     }
   }, [visible, reset, clearErrors]);
 
-  const onSubmit = (values: TaskFormValues) => {
-    console.log("CREATE_TASK", { date, ...values });
-    // フォームをリセット
-    reset();
-    onClose();
+  const onSubmit = async (values: TaskFormValues) => {
+    try {
+      console.log("CREATE_TASK", { date, ...values });
+      await db.insert(taskTable).values({ date, ...values });
+      // フォームをリセット
+      reset();
+      onClose();
+    } catch (error) {
+      console.error("CREATE_TASK_FAILED", error);
+    }
   };
 
   return (
@@ -131,7 +138,7 @@ export default function TaskFormDialog({
                     />
                     <View className="flex-row justify-end">
                       <Text className="text-xs text-gray-400 mt-1">
-                        {(value?.length ?? 0)}/100
+                        {value?.length ?? 0}/100
                       </Text>
                     </View>
                   </View>
@@ -169,7 +176,7 @@ export default function TaskFormDialog({
                     />
                     <View className="flex-row justify-end">
                       <Text className="text-xs text-gray-400 mt-1">
-                        {(value?.length ?? 0)}/200
+                        {value?.length ?? 0}/200
                       </Text>
                     </View>
                   </View>

--- a/db/addDummyData.ts
+++ b/db/addDummyData.ts
@@ -1,11 +1,11 @@
-import { tasks } from "@/db/schema";
+import { taskTable } from "@/db/schema";
 import { ExpoSQLiteDatabase } from "drizzle-orm/expo-sqlite";
 
 export default async function addDummyData(db: ExpoSQLiteDatabase) {
-  const count = await db.select().from(tasks);
+  const count = await db.select().from(taskTable);
   if (count.length > 0) return;
 
-  await db.insert(tasks).values([
+  await db.insert(taskTable).values([
     {
       date: "2024-01-15",
       content: "React Nativeの学習を開始する",

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-export const tasks = sqliteTable("tasks", {
+export const taskTable = sqliteTable("tasks", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   date: text("date").notNull(),
   content: text("content").notNull(), // タスクの内容
@@ -17,5 +17,5 @@ export const tasks = sqliteTable("tasks", {
     .default(sql`(datetime('now'))`),
 });
 
-export type Task = typeof tasks.$inferSelect;
-export type CreateTask = typeof tasks.$inferInsert;
+export type Task = typeof taskTable.$inferSelect;
+export type CreateTask = typeof taskTable.$inferInsert;


### PR DESCRIPTION
- データベース接続を`db`から取得するように変更
- タスクの取得、更新、追加処理を`drizzle-orm`を使用して実装
- マイグレーション処理を`MigrationGate`コンポーネントに分離
- タスクフォームダイアログでのタスク作成時にエラーハンドリングを追加
- 不要なダミーデータの追加処理を削除し、タスクテーブルのスキーマ名を統一